### PR TITLE
Update KDE Platform/SDK

### DIFF
--- a/org.mamedev.MAME.yaml
+++ b/org.mamedev.MAME.yaml
@@ -1,6 +1,6 @@
 id: org.mamedev.MAME
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 command: mame
 separate-locales: false
@@ -24,6 +24,7 @@ modules:
     build-commands:
       - make
           -j ${FLATPAK_BUILDER_N_JOBS}
+          CFLAGS+=-Wno-error=restrict
           USE_SYSTEM_LIB_FLAC=1
           SDL_INI_PATH='$$HOME/.APP_NAME;/app/share/APP_NAME/ini'
           LDOPTS=-Wl,-s


### PR DESCRIPTION
Bypass a GCC 12 false-positive warning that was forcing it to fail
